### PR TITLE
feat: 그룹 도메인 구현

### DIFF
--- a/src/main/java/org/konkuk/klab/mtot/domain/MemberTeam.java
+++ b/src/main/java/org/konkuk/klab/mtot/domain/MemberTeam.java
@@ -1,0 +1,36 @@
+package org.konkuk.klab.mtot.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberTeam {
+
+    @Id @GeneratedValue
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Team team;
+
+    public MemberTeam(Member member, Team team){
+        addMember(member);
+        addTeam(team);
+    }
+
+    private void addTeam(Team team) {
+        this.team = team;
+        team.getMemberTeams().add(this);
+    }
+
+    private void addMember(Member member) {
+        this.member = member;
+        member.getMemberTeams().add(this);
+    }
+}

--- a/src/main/java/org/konkuk/klab/mtot/domain/Team.java
+++ b/src/main/java/org/konkuk/klab/mtot/domain/Team.java
@@ -11,28 +11,22 @@ import java.util.List;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Member {
+public class Team {
 
     @Id @GeneratedValue
-    @Column(name = "member_id")
-    Long id;
+    private Long id;
 
     @Column(name = "name", nullable = false)
-    String name;
+    private String name;
 
-    @Column(name = "email", nullable = false)
-    String email;
+    @Column(name = "leader_id", nullable = false)
+    private Long leaderId;
 
-    @Column(name = "password", nullable = false)
-    String password;
-
-    @OneToMany(mappedBy = "member")
+    @OneToMany(mappedBy = "team")
     private List<MemberTeam> memberTeams = new ArrayList<>();
 
-    public Member(String name, String email, String password) {
+    public Team(String name, Long leaderId) {
         this.name = name;
-        this.email = email;
-        this.password = password;
+        this.leaderId = leaderId;
     }
-
 }

--- a/src/main/java/org/konkuk/klab/mtot/dto/request/MemberTeamJoinRequest.java
+++ b/src/main/java/org/konkuk/klab/mtot/dto/request/MemberTeamJoinRequest.java
@@ -1,0 +1,15 @@
+package org.konkuk.klab.mtot.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MemberTeamJoinRequest {
+    @NotNull(message = "그룹 ID는 필수 입력 사항입니다.")
+    private Long teamId;
+
+    @NotNull(message = "멤버 ID는 필수 입력 사항입니다.")
+    private Long memberId;
+}

--- a/src/main/java/org/konkuk/klab/mtot/dto/request/TeamCreateRequest.java
+++ b/src/main/java/org/konkuk/klab/mtot/dto/request/TeamCreateRequest.java
@@ -1,0 +1,17 @@
+package org.konkuk.klab.mtot.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class TeamCreateRequest {
+
+    @NotNull(message = "멤버 ID는 필수 입력 사항입니다.")
+    private Long memberId;
+
+    @NotNull(message = "그룹 이름은 필수 입력 사항입니다.")
+    private String teamName;
+
+}

--- a/src/main/java/org/konkuk/klab/mtot/dto/request/TeamJoinRequest.java
+++ b/src/main/java/org/konkuk/klab/mtot/dto/request/TeamJoinRequest.java
@@ -1,0 +1,12 @@
+package org.konkuk.klab.mtot.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class TeamJoinRequest {
+    private Long memberId;
+    private Long teamId;
+}
+

--- a/src/main/java/org/konkuk/klab/mtot/dto/response/MemberGetAllResponse.java
+++ b/src/main/java/org/konkuk/klab/mtot/dto/response/MemberGetAllResponse.java
@@ -1,0 +1,12 @@
+package org.konkuk.klab.mtot.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class MemberGetAllResponse {
+    List<MemberGetResponse> members;
+}

--- a/src/main/java/org/konkuk/klab/mtot/dto/response/MemberGetResponse.java
+++ b/src/main/java/org/konkuk/klab/mtot/dto/response/MemberGetResponse.java
@@ -1,0 +1,12 @@
+package org.konkuk.klab.mtot.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MemberGetResponse {
+    private Long id;
+    private String name;
+    private String email;
+}

--- a/src/main/java/org/konkuk/klab/mtot/dto/response/MemberSignUpResponse.java
+++ b/src/main/java/org/konkuk/klab/mtot/dto/response/MemberSignUpResponse.java
@@ -1,0 +1,10 @@
+package org.konkuk.klab.mtot.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MemberSignUpResponse {
+    private Long id;
+}

--- a/src/main/java/org/konkuk/klab/mtot/dto/response/MemberTeamGetAllResponse.java
+++ b/src/main/java/org/konkuk/klab/mtot/dto/response/MemberTeamGetAllResponse.java
@@ -1,0 +1,12 @@
+package org.konkuk.klab.mtot.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class MemberTeamGetAllResponse {
+    List<MemberTeamGetResponse> memberTeamList;
+}

--- a/src/main/java/org/konkuk/klab/mtot/dto/response/MemberTeamGetResponse.java
+++ b/src/main/java/org/konkuk/klab/mtot/dto/response/MemberTeamGetResponse.java
@@ -1,0 +1,11 @@
+package org.konkuk.klab.mtot.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MemberTeamGetResponse {
+    private Long memberId;
+    private Long groupId;
+}

--- a/src/main/java/org/konkuk/klab/mtot/dto/response/MemberTeamJoinResponse.java
+++ b/src/main/java/org/konkuk/klab/mtot/dto/response/MemberTeamJoinResponse.java
@@ -1,0 +1,10 @@
+package org.konkuk.klab.mtot.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MemberTeamJoinResponse {
+    private Long groupId;
+}

--- a/src/main/java/org/konkuk/klab/mtot/dto/response/TeamCreateResponse.java
+++ b/src/main/java/org/konkuk/klab/mtot/dto/response/TeamCreateResponse.java
@@ -1,0 +1,10 @@
+package org.konkuk.klab.mtot.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class TeamCreateResponse {
+    private Long groupId;
+}

--- a/src/main/java/org/konkuk/klab/mtot/dto/response/TeamJoinResponse.java
+++ b/src/main/java/org/konkuk/klab/mtot/dto/response/TeamJoinResponse.java
@@ -1,0 +1,10 @@
+package org.konkuk.klab.mtot.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class TeamJoinResponse {
+    private Long teamId;
+}

--- a/src/main/java/org/konkuk/klab/mtot/repository/MemberTeamRepository.java
+++ b/src/main/java/org/konkuk/klab/mtot/repository/MemberTeamRepository.java
@@ -1,0 +1,16 @@
+package org.konkuk.klab.mtot.repository;
+
+import org.konkuk.klab.mtot.domain.MemberTeam;
+import org.konkuk.klab.mtot.domain.Team;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface MemberTeamRepository extends JpaRepository<MemberTeam, Long> {
+    @Query("select mg from MemberTeam mg where mg.member.id =:memberId")
+    List<MemberTeam> findAllByMemberId(Long memberId);
+
+    Optional<MemberTeam> findByMemberIdAndTeamId(Long memberId, Long teamId);
+}

--- a/src/main/java/org/konkuk/klab/mtot/repository/TeamRepository.java
+++ b/src/main/java/org/konkuk/klab/mtot/repository/TeamRepository.java
@@ -1,0 +1,7 @@
+package org.konkuk.klab.mtot.repository;
+
+import org.konkuk.klab.mtot.domain.Team;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TeamRepository extends JpaRepository<Team, Long> {
+}

--- a/src/main/java/org/konkuk/klab/mtot/service/MemberService.java
+++ b/src/main/java/org/konkuk/klab/mtot/service/MemberService.java
@@ -3,9 +3,15 @@ package org.konkuk.klab.mtot.service;
 import lombok.RequiredArgsConstructor;
 import org.konkuk.klab.mtot.domain.Member;
 import org.konkuk.klab.mtot.dto.request.MemberSignUpRequest;
+import org.konkuk.klab.mtot.dto.response.MemberGetAllResponse;
+import org.konkuk.klab.mtot.dto.response.MemberGetResponse;
+import org.konkuk.klab.mtot.dto.response.MemberSignUpResponse;
 import org.konkuk.klab.mtot.repository.MemberRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -13,17 +19,26 @@ public class MemberService {
     private final MemberRepository memberRepository;
 
     @Transactional
-    public Long join(MemberSignUpRequest request){
-        validateDuplicateUsers(request);
+    public MemberSignUpResponse join(MemberSignUpRequest request){
+        validateDuplicateMembers(request);
         Member member = new Member(request.getName(), request.getEmail(), request.getPassword());
-        return memberRepository.save(member).getId();
+        return new MemberSignUpResponse(memberRepository.save(member).getId());
     }
 
-    private void validateDuplicateUsers(MemberSignUpRequest request){
+    private void validateDuplicateMembers(MemberSignUpRequest request){
         memberRepository.findByEmail(request.getEmail())
                 .ifPresent(member -> {
                     throw new RuntimeException("이미 존재하는 회원입니다.");
                 });
     }
 
+    public MemberGetAllResponse getAllMembers() {
+        List<MemberGetResponse> list = memberRepository.findAll()
+                .stream()
+                .map(member ->
+                    new MemberGetResponse(member.getId(), member.getName(), member.getEmail())
+                )
+                .collect(Collectors.toList());
+        return new MemberGetAllResponse(list);
+    }
 }

--- a/src/main/java/org/konkuk/klab/mtot/service/MemberTeamService.java
+++ b/src/main/java/org/konkuk/klab/mtot/service/MemberTeamService.java
@@ -1,0 +1,48 @@
+package org.konkuk.klab.mtot.service;
+
+import lombok.RequiredArgsConstructor;
+import org.konkuk.klab.mtot.domain.Team;
+import org.konkuk.klab.mtot.domain.Member;
+import org.konkuk.klab.mtot.domain.MemberTeam;
+import org.konkuk.klab.mtot.dto.response.MemberTeamGetAllResponse;
+import org.konkuk.klab.mtot.dto.response.MemberTeamGetResponse;
+import org.konkuk.klab.mtot.dto.response.MemberTeamJoinResponse;
+import org.konkuk.klab.mtot.dto.request.MemberTeamJoinRequest;
+import org.konkuk.klab.mtot.repository.TeamRepository;
+import org.konkuk.klab.mtot.repository.MemberTeamRepository;
+import org.konkuk.klab.mtot.repository.MemberRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class MemberTeamService {
+
+    private final MemberTeamRepository memberTeamRepository;
+    private final MemberRepository memberRepository;
+    private final TeamRepository teamRepository;
+    @Transactional
+    public MemberTeamJoinResponse registerMemberToTeam(MemberTeamJoinRequest request){
+        Member member = memberRepository.findById(request.getMemberId())
+                .orElseThrow(()-> new RuntimeException("ID에 해당하는 멤버를 찾을 수 없습니다."));
+        Team team = teamRepository.findById(request.getTeamId())
+                .orElseThrow(()-> new RuntimeException("ID에 해당하는 그룹를 찾을 수 없습니다."));
+
+        memberTeamRepository.findByMemberIdAndTeamId(request.getMemberId(), request.getTeamId())
+                .ifPresent(memberTeam -> {throw new RuntimeException("그룹에 이미 존재하는 멤버입니다.");});
+
+        memberTeamRepository.save(new MemberTeam(member, team));
+        return new MemberTeamJoinResponse(team.getId());
+    }
+
+    @Transactional(readOnly = true)
+    public MemberTeamGetAllResponse getMemberTeamsByMemberId(Long memberId){
+        List<MemberTeam> memberTeams = memberTeamRepository.findAllByMemberId(memberId);
+        return new MemberTeamGetAllResponse(memberTeams.stream()
+                .map(memberTeam -> new MemberTeamGetResponse(memberTeam.getMember().getId(), memberTeam.getTeam().getId()))
+                .toList());
+    }
+
+}

--- a/src/main/java/org/konkuk/klab/mtot/service/TeamService.java
+++ b/src/main/java/org/konkuk/klab/mtot/service/TeamService.java
@@ -1,0 +1,26 @@
+package org.konkuk.klab.mtot.service;
+
+import lombok.RequiredArgsConstructor;
+import org.konkuk.klab.mtot.domain.Team;
+import org.konkuk.klab.mtot.dto.request.MemberTeamJoinRequest;
+import org.konkuk.klab.mtot.dto.request.TeamCreateRequest;
+import org.konkuk.klab.mtot.dto.response.TeamCreateResponse;
+import org.konkuk.klab.mtot.repository.TeamRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class TeamService {
+
+    private final TeamRepository teamRepository;
+    private final MemberTeamService memberTeamService;
+
+    @Transactional
+    public TeamCreateResponse createTeam(TeamCreateRequest request){
+        Team team = new Team(request.getTeamName(), request.getMemberId());
+        Long teamId = teamRepository.save(team).getId();
+        memberTeamService.registerMemberToTeam(new MemberTeamJoinRequest(teamId, request.getMemberId()));
+        return new TeamCreateResponse(teamId);
+    }
+}

--- a/src/test/java/org/konkuk/klab/mtot/service/MemberTeamServiceTest.java
+++ b/src/test/java/org/konkuk/klab/mtot/service/MemberTeamServiceTest.java
@@ -1,0 +1,109 @@
+package org.konkuk.klab.mtot.service;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.konkuk.klab.mtot.domain.Member;
+import org.konkuk.klab.mtot.domain.MemberTeam;
+import org.konkuk.klab.mtot.domain.Team;
+import org.konkuk.klab.mtot.dto.request.MemberTeamJoinRequest;
+import org.konkuk.klab.mtot.repository.MemberRepository;
+import org.konkuk.klab.mtot.repository.MemberTeamRepository;
+import org.konkuk.klab.mtot.repository.TeamRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest
+class MemberTeamServiceTest {
+
+    @Autowired
+    MemberTeamService memberTeamService;
+    @Autowired
+    TeamRepository teamRepository;
+    @Autowired
+    MemberTeamRepository memberTeamRepository;
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Test
+    @DisplayName("멤버를 그룹에 추가한다.")
+    public void MemberTeamRegister() throws Exception{
+        //given
+        Member member = new Member("Lee", "abc@naver.com", "abcd12344");
+        Long memberId = memberRepository.save(member).getId();
+        Team team = new Team("New team", memberId);
+        Long teamId = teamRepository.save(team).getId();
+
+        //when
+        MemberTeamJoinRequest req = new MemberTeamJoinRequest(teamId, memberId);
+        memberTeamService.registerMemberToTeam(req);
+
+        //then
+        List<MemberTeam> all = memberTeamRepository.findAll();
+        assertThat(all).hasSize(1);
+        assertThat(all.get(0).getTeam().getId()).isEqualTo(teamId);
+        assertThat(all.get(0).getMember().getId()).isEqualTo(memberId);
+
+    }
+
+    @Test
+    @DisplayName("중복 그룹 추가를 방지한다.")
+    public void preventDuplicateMemberRegisteringTeam(){
+        // given
+        Member member = new Member("Lee", "abc@naver.com", "abcd12344");
+        Long memberId = memberRepository.save(member).getId();
+        Team team = new Team("New team", memberId);
+        Long teamId = teamRepository.save(team).getId();
+        MemberTeamJoinRequest req = new MemberTeamJoinRequest(teamId, memberId);
+        memberTeamService.registerMemberToTeam(req);
+
+        // when
+        assertThatThrownBy(()->{
+            memberTeamService.registerMemberToTeam(req);
+        }).isInstanceOf(RuntimeException.class);
+    }
+
+
+    @Test
+    @DisplayName("멤버 ID로 속한 팀 ID를 찾는다.")
+    public void getMemberTeamsByMemberId(){
+        // given
+        Member member1 = new Member("Lee", "abc@naver.com", "abcd12344");
+        Long member1Id = memberRepository.save(member1).getId();
+
+        Member member2 = new Member("Kim", "abcd@naver.com", "qwer1234");
+        Long member2Id = memberRepository.save(member2).getId();
+
+        Team team1 = new Team("New team", member1Id);
+        Team team2 = new Team("Team2", member1Id);
+        teamRepository.save(team1);
+        teamRepository.save(team2);
+
+        memberTeamRepository.save(new MemberTeam(member1, team1));
+        memberTeamRepository.save(new MemberTeam(member1, team2));
+        memberTeamRepository.save(new MemberTeam(member2, team1));
+
+        // team1: Lee, Kim, team2: Lee
+
+        // when
+        List<MemberTeam> allByMember1Id = memberTeamRepository.findAllByMemberId(member1Id);
+        List<MemberTeam> allByMember2Id = memberTeamRepository.findAllByMemberId(member2Id);
+
+        // then
+        assertThat(allByMember1Id).hasSize(2);
+        assertThat(allByMember2Id).hasSize(1);
+    }
+
+
+    @AfterEach
+    void tearDown(){
+        memberTeamRepository.deleteAll(); // 외래키 Delete 순서 고려해야 함
+        memberRepository.deleteAll();
+        teamRepository.deleteAll();
+    }
+}

--- a/src/test/java/org/konkuk/klab/mtot/service/TeamServiceTest.java
+++ b/src/test/java/org/konkuk/klab/mtot/service/TeamServiceTest.java
@@ -1,0 +1,58 @@
+package org.konkuk.klab.mtot.service;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.konkuk.klab.mtot.domain.MemberTeam;
+import org.konkuk.klab.mtot.domain.Team;
+import org.konkuk.klab.mtot.domain.Member;
+import org.konkuk.klab.mtot.dto.request.TeamCreateRequest;
+import org.konkuk.klab.mtot.repository.MemberTeamRepository;
+import org.konkuk.klab.mtot.repository.TeamRepository;
+import org.konkuk.klab.mtot.repository.MemberRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class TeamServiceTest {
+
+    @Autowired
+    TeamService teamService;
+    @Autowired
+    TeamRepository teamRepository;
+    @Autowired MemberRepository memberRepository;
+    @Autowired
+    MemberTeamRepository memberTeamRepository;
+
+    @Test
+    @DisplayName("그룹을 만들고, 그 멤버가 리더장이 된다.")
+    public void createGroupTest() throws Exception{
+        //given
+        Member member = new Member("Lee", "abc@naver.com", "abcd12344");
+        Long id = memberRepository.save(member).getId();
+        TeamCreateRequest request = new TeamCreateRequest(id, "My_Group");
+
+        //when
+        teamService.createTeam(request);
+
+
+        //then
+        List<Team> team = teamRepository.findAll();
+        assertThat(team).hasSize(1);
+        assertThat(team.get(0).getLeaderId()).isEqualTo(id);
+
+        List<MemberTeam> allByMemberId = memberTeamRepository.findAllByMemberId(id);
+        assertThat(allByMemberId).hasSize(1);
+    }
+
+
+    @AfterEach
+    void tearDown(){
+        memberTeamRepository.deleteAll();
+        teamRepository.deleteAll();
+        memberRepository.deleteAll();
+    }
+}


### PR DESCRIPTION
## 개요 🧾
<!-- 이곳에 PR의 내용을 간단하게 작성해주세요. -->
멤버를 기반으로 그룹, 다대다 연관관계에서의 중간 테이블을 구현했습니다.

## 변경사항 🛠
<!-- 이곳에 코드 변경 사항이나 추가된 사항에 대해서 작성해주세요. -->
Member / Team / 중간 테이블 MemberTeam  
그룹 생성, 그룹에 멤버 추가, 멤버 조회 등의 기능이 추가되었습니다.

## 주의사항 ⚠
<!-- 이곳에 리뷰어에게 할 말이나, 주의해야 하는 점에 대해서 작성해 주세요 -->
백엔드 담당: 코드 확인 뒤 코멘트와 함께 Approved를 해 주세요.

스프링에 대한 이해와 더불어 데이터베이스에 대한 이해도 필요합니다. 모르겠으면 꼭 물어봐 주세요.  

Group이라는 단어가 DB의 예약어라서 Team이라는 단어로 변경했습니다.
추가할 테스트 코드가 있는지 확인해 주세요.  
빠뜨린 기능이 없는지 확인해 주세요.  

멤버가 그룹을 만들 때, 자동으로 그룹장이 되어야 합니다.
TeamService에서 팀을 만들 때, 중간 테이블에 데이터가 들어가지 않아서 MemberTeamService의 의존성이 추가되었는데요, 
이를 제거하고 사용할 수 있는 다른 방법이 있을 지 궁금해요.

