### PR TITLE
feat: JourneyController 추가

### DIFF
--- a/src/main/java/org/konkuk/klab/mtot/controller/JourneyController.java
+++ b/src/main/java/org/konkuk/klab/mtot/controller/JourneyController.java
@@ -6,8 +6,6 @@ import org.konkuk.klab.mtot.service.JourneyService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.Objects;
-
 @RequestMapping("/journey")
 @RestController
 @RequiredArgsConstructor

--- a/src/main/java/org/konkuk/klab/mtot/controller/JourneyController.java
+++ b/src/main/java/org/konkuk/klab/mtot/controller/JourneyController.java
@@ -1,15 +1,9 @@
 package org.konkuk.klab.mtot.controller;
 
 import lombok.RequiredArgsConstructor;
-import org.konkuk.klab.mtot.domain.Journey;
-import org.konkuk.klab.mtot.domain.Team;
 import org.konkuk.klab.mtot.dto.response.CreateJourneyResponse;
-import org.konkuk.klab.mtot.dto.response.MemberGetAllResponse;
-import org.konkuk.klab.mtot.exception.TeamAccessDeniedException;
-import org.konkuk.klab.mtot.exception.TeamNotFoundException;
 import org.konkuk.klab.mtot.service.JourneyService;
 import org.springframework.http.ResponseEntity;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Objects;

--- a/src/main/java/org/konkuk/klab/mtot/controller/JourneyController.java
+++ b/src/main/java/org/konkuk/klab/mtot/controller/JourneyController.java
@@ -1,7 +1,11 @@
 package org.konkuk.klab.mtot.controller;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.konkuk.klab.mtot.dto.request.CreateJourneyRequest;
+import org.konkuk.klab.mtot.dto.request.MemberSignUpRequest;
 import org.konkuk.klab.mtot.dto.response.CreateJourneyResponse;
+import org.konkuk.klab.mtot.oauth.LoginMemberEmail;
 import org.konkuk.klab.mtot.service.JourneyService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -11,9 +15,9 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class JourneyController {
     private final JourneyService journeyService;
-    @PostMapping("/members/{memberEmail}/journies/{journeyName}/teams/{teamId}")
-    public ResponseEntity<CreateJourneyResponse> createJourney(@PathVariable("memberEmail") String memberEmail, @PathVariable("journeyName") String journeyName, @PathVariable("teamId") Long teamId){
-        CreateJourneyResponse createJourneyResponse = journeyService.createJourney(memberEmail, journeyName, teamId);
+    @PostMapping("/teams/{teamId}")
+    public ResponseEntity<CreateJourneyResponse> createJourney(@LoginMemberEmail String email, @RequestBody @Valid CreateJourneyRequest createJourneyRequest){
+        CreateJourneyResponse createJourneyResponse = journeyService.createJourney(email, createJourneyRequest.getJourneyName(), createJourneyRequest.getTeamId());
         return ResponseEntity.ok(createJourneyResponse);
     }
 }

--- a/src/main/java/org/konkuk/klab/mtot/controller/JourneyController.java
+++ b/src/main/java/org/konkuk/klab/mtot/controller/JourneyController.java
@@ -1,0 +1,27 @@
+package org.konkuk.klab.mtot.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.konkuk.klab.mtot.domain.Journey;
+import org.konkuk.klab.mtot.domain.Team;
+import org.konkuk.klab.mtot.dto.response.CreateJourneyResponse;
+import org.konkuk.klab.mtot.dto.response.MemberGetAllResponse;
+import org.konkuk.klab.mtot.exception.TeamAccessDeniedException;
+import org.konkuk.klab.mtot.exception.TeamNotFoundException;
+import org.konkuk.klab.mtot.service.JourneyService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Objects;
+
+@RequestMapping("/journey")
+@RestController
+@RequiredArgsConstructor
+public class JourneyController {
+    private final JourneyService journeyService;
+    @PostMapping("/members/{memberEmail}/journies/{journeyName}/teams/{teamId}")
+    public ResponseEntity<CreateJourneyResponse> createJourney(@PathVariable("memberEmail") String memberEmail, @PathVariable("journeyName") String journeyName, @PathVariable("teamId") Long teamId){
+        CreateJourneyResponse createJourneyResponse = journeyService.createJourney(memberEmail, journeyName, teamId);
+        return ResponseEntity.ok(createJourneyResponse);
+    }
+}

--- a/src/main/java/org/konkuk/klab/mtot/controller/JourneyController.java
+++ b/src/main/java/org/konkuk/klab/mtot/controller/JourneyController.java
@@ -3,7 +3,6 @@ package org.konkuk.klab.mtot.controller;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.konkuk.klab.mtot.dto.request.CreateJourneyRequest;
-import org.konkuk.klab.mtot.dto.request.MemberSignUpRequest;
 import org.konkuk.klab.mtot.dto.response.CreateJourneyResponse;
 import org.konkuk.klab.mtot.oauth.LoginMemberEmail;
 import org.konkuk.klab.mtot.service.JourneyService;

--- a/src/main/java/org/konkuk/klab/mtot/controller/JourneyController.java
+++ b/src/main/java/org/konkuk/klab/mtot/controller/JourneyController.java
@@ -4,6 +4,8 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.konkuk.klab.mtot.dto.request.CreateJourneyRequest;
 import org.konkuk.klab.mtot.dto.response.CreateJourneyResponse;
+import org.konkuk.klab.mtot.dto.response.GetJourneyListResponse;
+import org.konkuk.klab.mtot.dto.response.GetJourneyResponse;
 import org.konkuk.klab.mtot.oauth.LoginMemberEmail;
 import org.konkuk.klab.mtot.service.JourneyService;
 import org.springframework.http.ResponseEntity;
@@ -14,6 +16,20 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class JourneyController {
     private final JourneyService journeyService;
+
+    @GetMapping("/{journeyId}")
+    public ResponseEntity<GetJourneyResponse> getJourney(@LoginMemberEmail String email,
+                                                         @PathVariable("journeyId") Long journeyId){
+        GetJourneyResponse getJourneyResponse = journeyService.getJourney(email, journeyId);
+        return ResponseEntity.ok(getJourneyResponse);
+    }
+
+    @GetMapping
+    public ResponseEntity<GetJourneyListResponse> getJourneyList(@LoginMemberEmail String email){
+        GetJourneyListResponse getJourneyListResponse = journeyService.getJourneyList(email);
+        return ResponseEntity.ok(getJourneyListResponse);
+    }
+
     @PostMapping
     public ResponseEntity<CreateJourneyResponse> createJourney(@LoginMemberEmail String email, @RequestBody @Valid CreateJourneyRequest createJourneyRequest){
         CreateJourneyResponse createJourneyResponse = journeyService.createJourney(email, createJourneyRequest.getJourneyName(), createJourneyRequest.getTeamId());

--- a/src/main/java/org/konkuk/klab/mtot/controller/JourneyController.java
+++ b/src/main/java/org/konkuk/klab/mtot/controller/JourneyController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class JourneyController {
     private final JourneyService journeyService;
-    @PostMapping("/teams/{teamId}")
+    @PostMapping
     public ResponseEntity<CreateJourneyResponse> createJourney(@LoginMemberEmail String email, @RequestBody @Valid CreateJourneyRequest createJourneyRequest){
         CreateJourneyResponse createJourneyResponse = journeyService.createJourney(email, createJourneyRequest.getJourneyName(), createJourneyRequest.getTeamId());
         return ResponseEntity.ok(createJourneyResponse);

--- a/src/main/java/org/konkuk/klab/mtot/dto/request/CreateJourneyRequest.java
+++ b/src/main/java/org/konkuk/klab/mtot/dto/request/CreateJourneyRequest.java
@@ -1,0 +1,12 @@
+package org.konkuk.klab.mtot.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class CreateJourneyRequest {
+    private String journeyName;
+}

--- a/src/main/java/org/konkuk/klab/mtot/dto/request/CreateJourneyRequest.java
+++ b/src/main/java/org/konkuk/klab/mtot/dto/request/CreateJourneyRequest.java
@@ -9,4 +9,5 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class CreateJourneyRequest {
     private String journeyName;
+    private Long teamId;
 }

--- a/src/main/java/org/konkuk/klab/mtot/dto/response/GetJourneyListResponse.java
+++ b/src/main/java/org/konkuk/klab/mtot/dto/response/GetJourneyListResponse.java
@@ -1,0 +1,12 @@
+package org.konkuk.klab.mtot.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class GetJourneyListResponse {
+    private List<GetJourneyResponse> journeys;
+}

--- a/src/main/java/org/konkuk/klab/mtot/dto/response/GetJourneyResponse.java
+++ b/src/main/java/org/konkuk/klab/mtot/dto/response/GetJourneyResponse.java
@@ -1,0 +1,17 @@
+package org.konkuk.klab.mtot.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.konkuk.klab.mtot.domain.Pin;
+import org.konkuk.klab.mtot.domain.Post;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class GetJourneyResponse {
+    private Long journeyId;
+    private String name;
+    private Post post;
+    private List<Pin> pins;
+}

--- a/src/main/java/org/konkuk/klab/mtot/repository/JourneyRepository.java
+++ b/src/main/java/org/konkuk/klab/mtot/repository/JourneyRepository.java
@@ -2,7 +2,14 @@ package org.konkuk.klab.mtot.repository;
 
 import org.konkuk.klab.mtot.domain.Journey;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface JourneyRepository extends JpaRepository<Journey, Long> {
+
+    @Query("select journey from Journey journey join journey.team team join team.memberTeams memberTeam where memberTeam.member.id =: memberId")
+    List<Journey> getJourneysFromMember(@Param("memberId") Long memberId);
 
 }


### PR DESCRIPTION
## 개요 🧾
JourneyController에 필요한 최소한의 method를 추가하였습니다.

## 변경사항 🛠
email은 resolver를 통해 받아옵니다.
journeyName, teamId는 request body를 통해 받아옵니다.
생성된 journey의 id를 반환합니다.

## 주의사항 ⚠
Postman으로 아직 테스트가 진행되지 않았습니다.