### PR TITLE
/teams 요청 시 다른 id 반환 에러 수정

### DIFF
--- a/src/main/java/org/konkuk/klab/mtot/service/MemberTeamService.java
+++ b/src/main/java/org/konkuk/klab/mtot/service/MemberTeamService.java
@@ -54,7 +54,7 @@ public class MemberTeamService {
         return new MemberTeamGetAllResponse(memberTeams.size(),
                 memberTeams
                         .stream()
-                        .map(memberTeam -> new MemberTeamGetResponse(memberTeam.getId(), memberTeam.getTeam().getName()))
+                        .map(memberTeam -> new MemberTeamGetResponse(memberTeam.getTeam().getId(), memberTeam.getTeam().getName()))
                         .toList()
         );
     }


### PR DESCRIPTION
## 개요 🧾
/teams 요청 시 memberteam 테이블의 id를 가져와 문제가 발생함. 팀의 id를 반환해줘야함.

## 변경사항 🛠
<!-- 이곳에 코드 변경 사항이나 추가된 사항에 대해서 작성해주세요. -->

## 주의사항 ⚠
<!-- 이곳에 리뷰어에게 할 말이나, 주의해야 하는 점에 대해서 작성해 주세요 -->
